### PR TITLE
Added handling for Ping interruption in synchronous mode

### DIFF
--- a/library/src/main/java/com/stealthcopter/networktools/ping/PingTools.java
+++ b/library/src/main/java/com/stealthcopter/networktools/ping/PingTools.java
@@ -20,9 +20,13 @@ public class PingTools {
         try{
             PingResult result = PingTools.doNativePing(ia, timeOutMillis);
             return result;
+        } catch (InterruptedException e){
+            PingResult pingResult = new PingResult(ia);
+            pingResult.isReachable = false;
+            pingResult.error="Interrupted";
+            return pingResult;
         }
-        catch (Exception e){
-
+        catch (Exception ignored){
         }
 
         Log.v("AndroidNetworkTools", "Native ping failed, using java");
@@ -51,7 +55,7 @@ public class PingTools {
             if (!reached) pingResult.error="Timed Out";
         } catch (IOException e) {
             pingResult.isReachable=false;
-            pingResult.error="IOException";
+            pingResult.error="IOException: "+e.getMessage();
         }
         return pingResult;
     }


### PR DESCRIPTION
Native ping didn't react to thread interruption, this not very nice, especially while working in synchronous mode. This PR fixes this.

Also improved error reporting in java ping, a little bit :)